### PR TITLE
Switch scan example to use mDNS lib

### DIFF
--- a/examples/scan_airtunes.js
+++ b/examples/scan_airtunes.js
@@ -1,42 +1,11 @@
-var util = require('util'),
-    os = require('os'),
-    exec = require('child_process').exec;
+const mdns = require('mdns');
 
-if(os.platform() !== 'darwin') {
-  console.error('Sorry, this utility only works with OS X.');
-  process.exit(1);
-}
-
-// Mountain Lion 12.0.0 replaces mDNS with dns-sd
-if(os.release() < '12')
-  var mdns = 'mDNS';
-else
-  var mdns = 'dns-sd';
-
-exec(mdns + ' -B _raop._tcp', {
-  timeout: 300
-}, function(error, stdout) {
-  var devices = [];
-  stdout.split('\n').forEach(function(line) {
-    var res = /_raop\._tcp\.\s+([^@]+)@(.*)/.exec(line);
-    if(!res)
-      return;
-
-    devices.push({
-      mac: res[1],
-      name: res[2]
-    });
-  });
-
-  devices.forEach(function(dev) {
-    exec(mdns + ' -L "' + dev.mac + '@' + dev.name + '" _raop._tcp local', {
-      timeout: 300
-    }, function(error, stdout) {
-      var res = /can be reached at\s+(\S*)\s*:(\d+)/.exec(stdout);
-      if(!res)
-        console.log(dev.name + ' no match');
-      else
-        console.log(dev.name + ' ' + res[1] + ':' + res[2]);
-    });
-  });
+const browser = mdns.createBrowser(mdns.tcp('raop'));
+browser.on('serviceUp', service => {
+  console.log(
+    `${service.name} ${service.host}:${service.port}`
+  );
 });
+browser.start();
+
+setTimeout(() => {browser.stop()},300);

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   },
   "devDependencies": {
     "lame": "*",
-    "request": "^2.83.0",
-    "optimist": "*"
+    "mdns": "^2.5.1",
+    "optimist": "*",
+    "request": "^2.83.0"
   },
   "bugs": {
     "url": "https://github.com/mcfisto/node_airtunes2/issues"


### PR DESCRIPTION
Why: So that additional information can be inspected easily from JS. For example the full DNS record.