### PR TITLE
Fixed udp port binding with new version of async

### DIFF
--- a/lib/udp_servers.js
+++ b/lib/udp_servers.js
@@ -106,8 +106,8 @@ UDPServers.prototype.bind = function(host) {
   var current_port = config.udp_default_port;
 
   async.whilst(
-    function() { return to_bind.length > 0; },
-    function(cb) {
+      function(cb) { cb(null, to_bind.length > 0); },
+      function(cb) {
       var nextPort = to_bind[0];
       nextPort.socket.once('error', function(e) {
         if(e.code === 'EADDRINUSE') {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   ],
   "dependencies": {
-    "async": "*"
+    "async": "^3.2.0"
   },
   "devDependencies": {
     "lame": "*",


### PR DESCRIPTION
'async' introduced a breaking change to whilst in version 3.0.0: https://github.com/caolan/async/commit/bf7f054ca8801d4540fe49f7a4bb5d0575a53769.

The package 'async' had no locked version in package.json. This pull request fixes a whilst that's being used for udp port binding and locks the version of 'async' to 3.2.0.

Without these changes 'node_airtunes2' won't work on new installations. Alternative fix could be a version lock of 'async' prior to 3.