### PR TITLE
Use 'options' for rtsp heartbeat

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,7 +15,7 @@ var Config = {
   sync_period: 126,               // UDP sync packets are sent to all AirTunes devices regularly
   stream_latency: 50,             // audio UDP packets are flushed in bursts periodically
   rtsp_timeout: 5000,             // RTSP servers are considered gone if no reply is received before the timeout
-  rtsp_heartbeat: 60000,          // some RTSP (like HomePod) servers requires heartbeat. Recommanded value: 60000 (1 minute). Set to 0 if you want to disable it.
+  rtsp_heartbeat: 30000,          // some RTSP (like HomePod) servers requires heartbeat. Recommanded value: 60000 (1 minute). Set to 0 if you want to disable it.
   rtp_time_ref: 0,
   device_magic: nu.randomInt(9),
   ntp_epoch: 0x83aa7e80,

--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -141,11 +141,20 @@ Client.prototype.startHeartBeat = function() {
 
   if (config.rtsp_heartbeat > 0){
     this.heartBeat = setInterval(function() {
-      self.setTrackInfo('Radio', 'Stream', '', function(){
+      self.sendHeartBeat(function(){
         //console.log('HeartBeat sent!');
       });
     }, config.rtsp_heartbeat);
   }
+};
+
+Client.prototype.sendHeartBeat = function(callback) {
+  if(this.status !== PLAYING)
+    return;
+
+  this.status = OPTIONS;
+  this.callback = callback;
+  this.sendNextRequest();
 };
 
 Client.prototype.setTrackInfo = function(name, artist, album, callback) {
@@ -520,7 +529,7 @@ Client.prototype.processData = function(blob) {
       if(headers['Apple-Response'])
         this.requireEncryption = true;
 
-      this.status = ANNOUNCE;
+      this.status = this.session? PLAYING: ANNOUNCE;
       break;
 
     case ANNOUNCE:


### PR DESCRIPTION
The 'options' command is also a valid heartbeat. Using 'options' instead of 'setdaap' enables the use of setTrackInfo. Without this pull request the heartbeat overrides a previously set track info with 'stream' and 'radio' periodically.

This PR also sets the heartbeat to 30s since the HomePod (on v13.4) expects that.